### PR TITLE
fix: corrige Shuffle, reatribuição de e-mails e adiciona garantia de …

### DIFF
--- a/OccultFriend.Service/FriendServices/ServicesFriend.cs
+++ b/OccultFriend.Service/FriendServices/ServicesFriend.cs
@@ -1,4 +1,4 @@
-﻿using OccultFriend.Domain.DTO;
+using OccultFriend.Domain.DTO;
 using OccultFriend.Domain.IRepositories;
 using OccultFriend.Service.Interfaces;
 using System;
@@ -11,6 +11,8 @@ namespace OccultFriend.Service.FriendServices
     public class ServicesFriend : IServicesFriend
     {
         #region Attributes
+
+        private const int MaxShuffleAttempts = 10;
 
         readonly Random _random;
         private readonly IEmailService _emailService;
@@ -40,8 +42,7 @@ namespace OccultFriend.Service.FriendServices
         public async Task Draw(bool childWillPlay)
         {
             Friends = _repositoriesFriend.GetAll()
-                    .Select(f =>
-                    new FriendDto
+                    .Select(f => new FriendDto
                     {
                         Name = f.Name,
                         Description = f.Description,
@@ -49,19 +50,26 @@ namespace OccultFriend.Service.FriendServices
                         ImagePath = f.ImagePath
                     }).ToList();
 
-            var emails = Friends.Select(e => e.Email).ToArray();
+            // Captura os e-mails originais antes do embaralhamento para comparação posterior.
+            // Isso evita uma segunda query ao banco e permite validação posicional.
+            var originalEmails = Friends.Select(e => e.Email).ToArray();
 
-            Shuffle(emails);
+            bool ehRepeat;
+            int attempts = 0;
 
-            for (int i = 0; i <= Friends.Count; i++)
+            do
             {
-                foreach (string email in emails)
-                {
-                    Friends[i++].Email = email;
-                }
-            }
+                var emails = (string[])originalEmails.Clone();
+                Shuffle(emails);
 
-            var ehRepeat = ValidationRepeatDrawn();
+                for (int i = 0; i < Friends.Count; i++)
+                    Friends[i].Email = emails[i];
+
+                _friendsRepeateds = null;
+                ehRepeat = ValidationRepeatDrawn(originalEmails);
+                attempts++;
+
+            } while (ehRepeat && attempts < MaxShuffleAttempts);
 
             if (ehRepeat)
                 await _emailService.SendEmailAdminService(FriendsRepeateds);
@@ -72,16 +80,17 @@ namespace OccultFriend.Service.FriendServices
             }
         }
 
-        private void Shuffle<T>(T[] emails)
+        // Fisher-Yates correto: um único número aleatório por iteração no intervalo [0, index).
+        // Garante distribuição uniforme de todas as permutações possíveis.
+        private void Shuffle<T>(T[] array)
         {
-            for (int index = emails.Length; index > 1; index--)
+            for (int index = array.Length; index > 1; index--)
             {
-                int shuffle = MethodRandom(index);
-                int indexRandom = MethodRandom(shuffle); //Embaralha mais uma vez para garantir que não irá repetir o mesmo participante.
+                int indexRandom = MethodRandom(index);
 
-                T email = emails[indexRandom];
-                emails[indexRandom] = emails[index - 1];
-                emails[index - 1] = email;
+                T temp = array[indexRandom];
+                array[indexRandom] = array[index - 1];
+                array[index - 1] = temp;
             }
         }
 
@@ -90,26 +99,30 @@ namespace OccultFriend.Service.FriendServices
             return _random.Next(index);
         }
 
-        private bool ValidationRepeatDrawn()
+        // Valida duas condições independentes:
+        // 1. Auto-sorteio: participante tirou a si mesmo (comparação posicional com originalEmails).
+        // 2. Alvo duplicado: o mesmo participante foi sorteado por mais de uma pessoa.
+        //    Embora matematicamente impossível com permutação pura, a verificação explícita
+        //    garante a integridade independente da ordem de cadastro no banco.
+        private bool ValidationRepeatDrawn(string[] originalEmails)
         {
-            var repeat = false;
-            var friends = _repositoriesFriend.GetAll();
+            var assignedEmails = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var friend in friends)
+            for (int i = 0; i < Friends.Count; i++)
             {
-                var friendRepeat = Friends.First(x => x.Email.Equals(friend.Email));
+                var assignedEmail = Friends[i].Email;
 
-                if (friend.Email.Equals(friendRepeat.Email) && friend.Name.Equals(friendRepeat.Name))
-                {
-                    FriendsRepeateds.Add(friendRepeat);
-                    repeat = true;
-                }
+                if (assignedEmail.Equals(originalEmails[i], StringComparison.OrdinalIgnoreCase))
+                    FriendsRepeateds.Add(Friends[i]);
+
+                if (!assignedEmails.Add(assignedEmail))
+                    FriendsRepeateds.Add(Friends[i]);
             }
 
-            return repeat;
+            return FriendsRepeateds.Any();
         }
 
-        // Foi criado esse método para crianças que não possuem email, criei um email Alternativo para os dois responsáveis.
+        // Foi criado esse método para crianças que não possuem email, criando um email alternativo para os responsáveis.
         // To-Do ---- Ainda terei que implementar melhorias.
         private async Task SendEmailResponsible(bool childWillPlay)
         {

--- a/OccultFriend.Test/ServiceTest/ServicesFriendTest.cs
+++ b/OccultFriend.Test/ServiceTest/ServicesFriendTest.cs
@@ -1,8 +1,12 @@
-﻿using Moq;
+using Moq;
+using OccultFriend.Domain.DTO;
 using OccultFriend.Domain.IRepositories;
 using OccultFriend.Service.FriendServices;
 using OccultFriend.Service.Interfaces;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OccultFriend.Test.ServiceTest
@@ -17,16 +21,141 @@ namespace OccultFriend.Test.ServiceTest
         {
             _emailServiceMock = new Mock<IEmailService>();
             _repositoryFriendMock = new Mock<IRepositoriesFriend>();
-
             _friendServiceTest = new ServicesFriend(_emailServiceMock.Object, _repositoryFriendMock.Object);
         }
 
         [Fact]
-        public void Should_Draw_When_Informed_if_isChildren()
+        public async Task Draw_WhenRepositoryReturnsNull_ShouldThrowException()
         {
-            var isChildren = false;
+            _repositoryFriendMock.Setup(r => r.GetAll()).Returns((IEnumerable<FriendDto>)null);
 
-            Assert.ThrowsAsync<NullReferenceException>(() => _friendServiceTest.Draw(isChildren));
+            await Assert.ThrowsAsync<Exception>(() => _friendServiceTest.Draw(false));
         }
+
+        [Fact]
+        public async Task Draw_WithMultipleParticipants_ShouldNotSelfAssign()
+        {
+            var friends = BuildFriendList(5);
+
+            _repositoryFriendMock.Setup(r => r.GetAll()).Returns(friends);
+            _emailServiceMock
+                .Setup(e => e.SendEmailParticipantService(It.IsAny<IEnumerable<FriendDto>>()))
+                .Returns(Task.CompletedTask);
+
+            await _friendServiceTest.Draw(false);
+
+            // Com 5 participantes o retry garante sorteio válido — admin não deve ser notificado
+            _emailServiceMock.Verify(
+                e => e.SendEmailAdminService(It.IsAny<IEnumerable<FriendDto>>()),
+                Times.Never);
+        }
+
+        // Garante que cada participante é sorteado por exatamente uma pessoa,
+        // independente da ordem de cadastro no banco de dados.
+        [Fact]
+        public async Task Draw_WithMultipleParticipants_EachPersonDrawnExactlyOnce()
+        {
+            var friends = BuildFriendList(5);
+            var originalEmails = friends.Select(f => f.Email).ToHashSet();
+            List<FriendDto> capturedResult = null;
+
+            _repositoryFriendMock.Setup(r => r.GetAll()).Returns(friends);
+            _emailServiceMock
+                .Setup(e => e.SendEmailParticipantService(It.IsAny<IEnumerable<FriendDto>>()))
+                .Callback<IEnumerable<FriendDto>>(result => capturedResult = result.ToList())
+                .Returns(Task.CompletedTask);
+
+            await _friendServiceTest.Draw(false);
+
+            Assert.NotNull(capturedResult);
+
+            var assignedEmails = capturedResult.Select(f => f.Email).ToList();
+
+            // Cada participante foi sorteado por alguém
+            Assert.Equal(friends.Count, assignedEmails.Count);
+
+            // Nenhum participante foi sorteado mais de uma vez (sem alvos duplicados)
+            Assert.Equal(assignedEmails.Count, assignedEmails.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+
+            // Todos os e-mails sorteados pertencem a participantes da lista original
+            Assert.All(assignedEmails, email => Assert.Contains(email, originalEmails));
+        }
+
+        [Fact]
+        public async Task Draw_WithMultipleParticipants_NoOneShouldDrawThemselves()
+        {
+            var friends = BuildFriendList(5);
+            List<FriendDto> capturedResult = null;
+
+            _repositoryFriendMock.Setup(r => r.GetAll()).Returns(friends);
+            _emailServiceMock
+                .Setup(e => e.SendEmailParticipantService(It.IsAny<IEnumerable<FriendDto>>()))
+                .Callback<IEnumerable<FriendDto>>(result => capturedResult = result.ToList())
+                .Returns(Task.CompletedTask);
+
+            await _friendServiceTest.Draw(false);
+
+            Assert.NotNull(capturedResult);
+
+            // Nenhum participante deve ter sido sorteado com seu próprio e-mail
+            for (int i = 0; i < friends.Count; i++)
+            {
+                Assert.NotEqual(
+                    friends[i].Email,
+                    capturedResult[i].Email,
+                    StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public async Task Draw_WithSingleParticipant_ShouldExhaustAttemptsAndNotifyAdmin()
+        {
+            // Com 1 participante, o auto-sorteio é inevitável — admin deve ser notificado
+            var friends = BuildFriendList(1);
+
+            _repositoryFriendMock.Setup(r => r.GetAll()).Returns(friends);
+            _emailServiceMock
+                .Setup(e => e.SendEmailAdminService(It.IsAny<IEnumerable<FriendDto>>()))
+                .Returns(Task.CompletedTask);
+
+            await _friendServiceTest.Draw(false);
+
+            _emailServiceMock.Verify(
+                e => e.SendEmailAdminService(It.IsAny<IEnumerable<FriendDto>>()),
+                Times.Once);
+
+            _emailServiceMock.Verify(
+                e => e.SendEmailParticipantService(It.IsAny<IEnumerable<FriendDto>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task Draw_ShouldCallGetAllExactlyOnce()
+        {
+            // Valida que a segunda query ao banco foi eliminada
+            var friends = BuildFriendList(3);
+
+            _repositoryFriendMock.Setup(r => r.GetAll()).Returns(friends);
+            _emailServiceMock
+                .Setup(e => e.SendEmailParticipantService(It.IsAny<IEnumerable<FriendDto>>()))
+                .Returns(Task.CompletedTask);
+            _emailServiceMock
+                .Setup(e => e.SendEmailAdminService(It.IsAny<IEnumerable<FriendDto>>()))
+                .Returns(Task.CompletedTask);
+
+            await _friendServiceTest.Draw(false);
+
+            _repositoryFriendMock.Verify(r => r.GetAll(), Times.Once);
+        }
+
+        private static List<FriendDto> BuildFriendList(int count) =>
+            Enumerable.Range(1, count).Select(i => new FriendDto
+            {
+                Id = i,
+                Name = $"Friend{i}",
+                Email = $"friend{i}@test.com",
+                Description = $"Description{i}",
+                IsChildreen = false
+            }).ToList();
     }
 }


### PR DESCRIPTION
…alvo único

- Fisher-Yates corrigido: remove segundo MethodRandom que causava distribuição enviesada
- Loop de reatribuição simplificado para evitar IndexOutOfRangeException
- ValidationRepeatDrawn refatorada: elimina segunda query ao banco, usa comparação posicional com originalEmails e verifica explicitamente alvos duplicados via HashSet
- Retry com limite de 10 tentativas antes de notificar o admin
- Comparação de e-mails com OrdinalIgnoreCase para evitar falsos negativos por casing
- Testes atualizados: cobertura de auto-sorteio, alvo único, sem duplicatas e GetAll×1

https://claude.ai/code/session_01HRV5stVF8rDaEjLJ1yaa2v